### PR TITLE
translations history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 *.class
 *.log
+.Michelson.js
+.MichelsonTranslator.js
+package-lock.json
+
+target/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -3,13 +3,21 @@
 REST API for translating from `Michelson` to `Micheline` and back.
 It utilizes [Tezos-FullStack-Console-Translation-Module](https://github.com/ScalaConsultants/Tezos-FullStack-Console-Translation-Module) to perform it.
 
+## Prerequisites
+* JDK (> 8.x)
+* Scala (> 2.12.8)
+* SBT (> 1.2.8)
+* Node.js with nearly ([Tezos-FullStack-Console-Translation-Module](https://github.com/ScalaConsultants/Tezos-FullStack-Console-Translation-Module) requires it)
+
 ## Usage
 
 1. Clone repo
 
-2. Run `sbt run`
+2. Run `npm install`
 
-3. Query your local instance with exemplary snippets
+3. Run `sbt run`
+
+4. Query your local instance with exemplary snippets
 
 From `Michelson` to `Micheline`:
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ REST API for translating from `Michelson` to `Micheline` and back.
 It utilizes [Tezos-FullStack-Console-Translation-Module](https://github.com/ScalaConsultants/Tezos-FullStack-Console-Translation-Module) to perform it.
 
 ## Prerequisites
-* JDK (> 8.x)
+* JDK (>= 8.x)
 * Scala (> 2.12.8)
 * SBT (> 1.2.8)
 * Node.js with nearly ([Tezos-FullStack-Console-Translation-Module](https://github.com/ScalaConsultants/Tezos-FullStack-Console-Translation-Module) requires it)
+* mysql database
 
 ## Usage
 
@@ -15,9 +16,11 @@ It utilizes [Tezos-FullStack-Console-Translation-Module](https://github.com/Scal
 
 2. Run `npm install`
 
-3. Run `sbt run`
+3. Configure mysql access in `application.conf`
 
-4. Query your local instance with exemplary snippets
+4. Run `sbt run`
+
+5. Query your local instance with exemplary snippets
 
 From `Michelson` to `Micheline`:
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,15 +10,19 @@ resolvers += "typesafe" at "http://repo.typesafe.com/typesafe/releases/"
 
 resolvers += "Scalac" at "https://raw.githubusercontent.com/ScalaConsultants/mvn-repo/master/"
 
+val akkaHttpVersion = "10.1.10"
+
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-http"   % "10.1.9",
-  "com.typesafe.akka" %% "akka-stream" % "2.5.23",
-  "org.scalactic" %% "scalactic" % "3.0.5",
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test",
-  "com.typesafe.akka" %% "akka-stream-testkit" % "2.5.23",
-  "com.typesafe.akka" %% "akka-http-testkit" % "10.1.8",
-  "io.scalac" %% "tezos-fullstack-console-translation-module" % "0.1",
-  "ch.megard" %% "akka-http-cors" % "0.4.1"
+  "com.typesafe.akka" %% "akka-http"            % akkaHttpVersion,
+  "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion,
+  "com.typesafe.akka" %% "akka-stream"          % "2.5.23",
+  "ch.megard"         %% "akka-http-cors"       % "0.4.1",
+  "org.scalactic"     %% "scalactic"            % "3.0.5",
+  "io.scalac"         %% "tezos-fullstack-console-translation-module" % "0.1",
+//  test
+  "org.scalatest"     %% "scalatest"            % "3.0.5" % "test",
+  "com.typesafe.akka" %% "akka-stream-testkit"  % "2.5.23" % "test",
+  "com.typesafe.akka" %% "akka-http-testkit"    % akkaHttpVersion % "test",
 )
 
 // No need to run tests while building jar

--- a/build.sbt
+++ b/build.sbt
@@ -13,16 +13,22 @@ resolvers += "Scalac" at "https://raw.githubusercontent.com/ScalaConsultants/mvn
 val akkaHttpVersion = "10.1.10"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-http"            % akkaHttpVersion,
-  "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion,
-  "com.typesafe.akka" %% "akka-stream"          % "2.5.23",
-  "ch.megard"         %% "akka-http-cors"       % "0.4.1",
-  "org.scalactic"     %% "scalactic"            % "3.0.5",
-  "io.scalac"         %% "tezos-fullstack-console-translation-module" % "0.1",
+  "com.typesafe.akka"  %% "akka-http"            % akkaHttpVersion,
+  "com.typesafe.akka"  %% "akka-http-spray-json" % akkaHttpVersion,
+  "com.typesafe.akka"  %% "akka-stream"          % "2.5.23",
+  "ch.megard"          %% "akka-http-cors"       % "0.4.1",
+  "org.scalactic"      %% "scalactic"            % "3.0.5",
+  "io.scalac"          %% "tezos-fullstack-console-translation-module" % "0.1",
+  "com.typesafe.slick" %% "slick"                % "3.3.1",
+  "org.slf4j"           %  "slf4j-api"           % "1.7.26",
+  "ch.qos.logback"      % "logback-classic"      % "1.2.3",
+  "com.typesafe.slick" %% "slick-hikaricp"       % "3.3.1",
+  "mysql"               % "mysql-connector-java" % "8.0.17",
+  "joda-time"           % "joda-time"            % "2.10.4",
 //  test
-  "org.scalatest"     %% "scalatest"            % "3.0.5" % "test",
-  "com.typesafe.akka" %% "akka-stream-testkit"  % "2.5.23" % "test",
-  "com.typesafe.akka" %% "akka-http-testkit"    % akkaHttpVersion % "test",
+  "org.scalatest"      %% "scalatest"            % "3.0.5" % "test",
+  "com.typesafe.akka"  %% "akka-stream-testkit"  % "2.5.23" % "test",
+  "com.typesafe.akka"  %% "akka-http-testkit"    % akkaHttpVersion % "test",
 )
 
 // No need to run tests while building jar

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "my-node",
+  "version": "1.0.0",
+  "dependencies": {
+    "nearley": "^2.16.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-node",
+  "name": "tezos-translator",
   "version": "1.0.0",
   "dependencies": {
     "nearley": "^2.16.0"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -7,3 +7,21 @@ console {
   }
 }
 
+tezos-db {
+  db_ip = "127.0.0.1"
+  db_ip = ${?TEZOS_DB_IP}
+  db_port = "3306"
+  db_port = ${?TEZOS_DB_PORT}
+  db_name = "tezos"
+  db_name = ${?TEZOS_DB_NAME}
+
+  driver = "com.mysql.cj.jdbc.Driver",
+  url = "jdbc:mysql://"${tezos-db.db_ip}":"${tezos-db.db_port}"/"${tezos-db.db_name}"?useSSL=false",
+  user = "tezos"
+  user = ${?TEZOS_DB_USERNAME}
+  password = "Tez0s"
+  password = ${?TEZOS_DB_PASSWORD}
+  connectionPool = "HikariCP"
+  maxThread = 10
+}
+

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="akka" level="WARN" />
+<!--    <logger name="slick.jdbc.JdbcBackend.statement" level="DEBUG" />-->
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/src/main/scala/io/scalac/tezos/translator/Boot.scala
+++ b/src/main/scala/io/scalac/tezos/translator/Boot.scala
@@ -19,7 +19,9 @@ object Boot {
     val host = httpConfig.getString("host")
     val port = httpConfig.getInt("port")
 
-    val bindingFuture: Future[Http.ServerBinding] = Routes.setupRoutes(host, port)
+    val routes = new Routes(new TranslationsService)
+
+    val bindingFuture: Future[Http.ServerBinding] = Http().bindAndHandle(routes.allRoutes, host, port)
 
     println(s"Server online at http://$host:$port\nPress RETURN to stop...")
 

--- a/src/main/scala/io/scalac/tezos/translator/Boot.scala
+++ b/src/main/scala/io/scalac/tezos/translator/Boot.scala
@@ -8,9 +8,11 @@ import com.typesafe.config.ConfigFactory
 import scala.concurrent.Future
 import scala.io.StdIn
 
+import slick.jdbc.MySQLProfile.api._
+
 object Boot {
   def main(args: Array[String]): Unit = {
-    implicit val system = ActorSystem("my-system")
+    implicit val system = ActorSystem("tezos-translator")
     implicit val materializer = ActorMaterializer()
     implicit val executionContext = system.dispatcher
 
@@ -18,6 +20,9 @@ object Boot {
     val httpConfig = config.getConfig("http")
     val host = httpConfig.getString("host")
     val port = httpConfig.getInt("port")
+
+    implicit val db = Database.forConfig("tezos-db")
+    implicit val repository = new TranslationRepository
 
     val routes = new Routes(new TranslationsService)
 

--- a/src/main/scala/io/scalac/tezos/translator/TranslationRepository.scala
+++ b/src/main/scala/io/scalac/tezos/translator/TranslationRepository.scala
@@ -1,0 +1,20 @@
+package io.scalac.tezos.translator
+
+import io.scalac.tezos.translator.model.{Translation, TranslationDomainModel}
+import io.scalac.tezos.translator.schema.TranslationTable
+import slick.jdbc.MySQLProfile.api._
+import io.scalac.tezos.translator.schema._
+
+class TranslationRepository {
+
+  def add(translation: TranslationDomainModel): DBIO[Int] =
+    TranslationTable.translations += translation
+
+  def list(fromFilter: Option[Translation.From], limit: Int): DBIO[Seq[TranslationDomainModel]] =
+    TranslationTable.translations
+    .filterOpt(fromFilter)(_.from === _ )
+    .sortBy(_.createdAt.desc)
+    .take(limit)
+    .result
+
+}

--- a/src/main/scala/io/scalac/tezos/translator/TranslationsService.scala
+++ b/src/main/scala/io/scalac/tezos/translator/TranslationsService.scala
@@ -1,0 +1,29 @@
+package io.scalac.tezos.translator
+
+import io.scalac.tezos.translator.model.{History, Translation}
+
+import scala.collection.mutable
+
+class TranslationsService {
+
+  private val maxReturnSize: Int = 10
+  private val maxSize: Int = 100
+
+  private val translations = mutable.MutableList[History]()
+
+  def addTranslation(from: Translation.From, source: String, translation: String): Unit = {
+    translations += model.History(from, source, translation)
+
+    if(translations.size > maxSize) {
+      translations.dropRight(translations.size - maxSize)
+    }
+  }
+
+  def list(fromFilter: Option[Translation.From]): List[History] =
+    fromFilter.map { from =>
+      translations.filter(_.from == from).take(maxReturnSize).toList
+    }.getOrElse(
+      translations.take(maxReturnSize).toList
+    )
+
+}

--- a/src/main/scala/io/scalac/tezos/translator/model/History.scala
+++ b/src/main/scala/io/scalac/tezos/translator/model/History.scala
@@ -1,3 +1,0 @@
-package io.scalac.tezos.translator.model
-
-case class History(from: Translation.From, source: String, translation: String)

--- a/src/main/scala/io/scalac/tezos/translator/model/History.scala
+++ b/src/main/scala/io/scalac/tezos/translator/model/History.scala
@@ -1,0 +1,3 @@
+package io.scalac.tezos.translator.model
+
+case class History(from: Translation.From, source: String, translation: String)

--- a/src/main/scala/io/scalac/tezos/translator/model/HistoryViewModel.scala
+++ b/src/main/scala/io/scalac/tezos/translator/model/HistoryViewModel.scala
@@ -1,0 +1,12 @@
+package io.scalac.tezos.translator.model
+
+case class HistoryViewModel(source: String, translation: String)
+
+object HistoryViewModelExtension {
+
+  implicit class HistoryExtension(history: History) {
+
+    def toViewModel: HistoryViewModel = HistoryViewModel(history.source, history.translation)
+  }
+
+}

--- a/src/main/scala/io/scalac/tezos/translator/model/HistoryViewModel.scala
+++ b/src/main/scala/io/scalac/tezos/translator/model/HistoryViewModel.scala
@@ -4,7 +4,7 @@ case class HistoryViewModel(source: String, translation: String)
 
 object HistoryViewModelExtension {
 
-  implicit class HistoryExtension(history: History) {
+  implicit class HistoryExtension(history: TranslationDomainModel) {
 
     def toViewModel: HistoryViewModel = HistoryViewModel(history.source, history.translation)
   }

--- a/src/main/scala/io/scalac/tezos/translator/model/Translation.scala
+++ b/src/main/scala/io/scalac/tezos/translator/model/Translation.scala
@@ -9,6 +9,17 @@ object Translation {
   case object FromMicheline extends From
   case object FromMichelson extends From
 
+  def asString(r: From) = r match {
+    case FromMicheline => "micheline"
+    case FromMichelson => "michelson"
+  }
+
+  def fromString(s: String): Option[From] = s.toLowerCase match {
+    case "micheline" => Some(FromMicheline)
+    case "michelson" => Some(FromMichelson)
+    case _ => None
+  }
+
   implicit val fromDeserializer = Unmarshaller.strict[String, From] { string =>
     string.toLowerCase match {
       case "micheline" => FromMicheline

--- a/src/main/scala/io/scalac/tezos/translator/model/Translation.scala
+++ b/src/main/scala/io/scalac/tezos/translator/model/Translation.scala
@@ -1,0 +1,19 @@
+package io.scalac.tezos.translator.model
+
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+
+object Translation {
+
+  sealed trait From
+
+  case object FromMicheline extends From
+  case object FromMichelson extends From
+
+  implicit val fromDeserializer = Unmarshaller.strict[String, From] { string =>
+    string.toLowerCase match {
+      case "micheline" => FromMicheline
+      case "michelson" => FromMichelson
+      case x => throw new IllegalArgumentException(s"'$x' is not a valid `source` value")
+    }
+  }
+}

--- a/src/main/scala/io/scalac/tezos/translator/model/TranslationDomainModel.scala
+++ b/src/main/scala/io/scalac/tezos/translator/model/TranslationDomainModel.scala
@@ -1,0 +1,9 @@
+package io.scalac.tezos.translator.model
+
+import org.joda.time.DateTime
+
+case class TranslationDomainModel(id: Option[Long],
+                                  from: Translation.From,
+                                  source: String,
+                                  translation: String,
+                                  createdAt: DateTime)

--- a/src/main/scala/io/scalac/tezos/translator/routes/HistoryRoutes.scala
+++ b/src/main/scala/io/scalac/tezos/translator/routes/HistoryRoutes.scala
@@ -1,0 +1,25 @@
+package io.scalac.tezos.translator.routes
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import io.scalac.tezos.translator.TranslationsService
+import io.scalac.tezos.translator.model.{HistoryViewModel, Translation}
+import io.scalac.tezos.translator.model.HistoryViewModelExtension._
+import spray.json._
+
+trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+  implicit val historyViewModelFormat = jsonFormat2(HistoryViewModel)
+}
+
+class HistoryRoutes(translationsService: TranslationsService) extends HttpRoutes with JsonSupport {
+
+  override def routes =
+    pathPrefix("translations") {
+      pathEndOrSingleSlash {
+        get {
+          parameters('source.as[Translation.From].?) { sourceOpt =>
+            complete(translationsService.list(sourceOpt).map(_.toViewModel))
+          }
+        }
+      }
+    }
+}

--- a/src/main/scala/io/scalac/tezos/translator/routes/HistoryRoutes.scala
+++ b/src/main/scala/io/scalac/tezos/translator/routes/HistoryRoutes.scala
@@ -6,18 +6,25 @@ import io.scalac.tezos.translator.model.{HistoryViewModel, Translation}
 import io.scalac.tezos.translator.model.HistoryViewModelExtension._
 import spray.json._
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val historyViewModelFormat = jsonFormat2(HistoryViewModel)
 }
 
 class HistoryRoutes(translationsService: TranslationsService) extends HttpRoutes with JsonSupport {
 
+  val defaultResultLimit: Int = 10
+
   override def routes =
     pathPrefix("translations") {
       pathEndOrSingleSlash {
         get {
-          parameters('source.as[Translation.From].?) { sourceOpt =>
-            complete(translationsService.list(sourceOpt).map(_.toViewModel))
+          parameters('source.as[Translation.From].?, 'limit.as[Int].?) { (sourceOpt, limitOpt) =>
+            val result = for {
+              translations <- translationsService.list(sourceOpt, limitOpt.getOrElse(defaultResultLimit))
+            } yield translations.map(_.toViewModel)
+            complete(result)
           }
         }
       }

--- a/src/main/scala/io/scalac/tezos/translator/routes/HttpRoutes.scala
+++ b/src/main/scala/io/scalac/tezos/translator/routes/HttpRoutes.scala
@@ -1,0 +1,8 @@
+package io.scalac.tezos.translator.routes
+
+import akka.http.scaladsl.server.{Directives, Route}
+
+trait HttpRoutes extends Directives {
+
+  def routes: Route
+}

--- a/src/main/scala/io/scalac/tezos/translator/routes/TranslatorRoutes.scala
+++ b/src/main/scala/io/scalac/tezos/translator/routes/TranslatorRoutes.scala
@@ -1,0 +1,41 @@
+package io.scalac.tezos.translator.routes
+
+import akka.http.scaladsl.model.{ContentType, HttpEntity, HttpResponse, MediaTypes, StatusCodes}
+import io.scalac.tezos.translator.TranslationsService
+import io.scalac.tezos.translator.micheline.MichelineTranslator
+import io.scalac.tezos.translator.michelson.JsonToMichelson
+import io.scalac.tezos.translator.michelson.dto.MichelsonSchema
+import io.scalac.tezos.translator.model.Translation
+
+class TranslatorRoutes(translationsService: TranslationsService) extends HttpRoutes {
+
+  override def routes =
+    pathPrefix("translate") {
+      path("from" / "michelson" / "to" / "micheline") {
+        post {
+          entity(as[String]) { body =>
+            MichelineTranslator.michelsonToMicheline(body).fold(
+              error => complete(StatusCodes.BadRequest, error.toString),
+              parsed => {
+                translationsService.addTranslation(Translation.FromMichelson, body, parsed)
+                complete(HttpResponse(entity = HttpEntity(ContentType(MediaTypes.`application/json`), parsed)))
+              }
+            )
+          }
+        }
+      } ~ path("from" / "micheline" / "to" / "michelson") {
+        post {
+          entity(as[String]) { body =>
+            JsonToMichelson.convert[MichelsonSchema](body).fold(
+              error => complete(StatusCodes.BadRequest, error.toString),
+              parsed => {
+                translationsService.addTranslation(Translation.FromMicheline, body, parsed)
+                complete(parsed)
+              }
+            )
+          }
+        }
+      }
+    }
+
+}

--- a/src/main/scala/io/scalac/tezos/translator/schema/TranslationTable.scala
+++ b/src/main/scala/io/scalac/tezos/translator/schema/TranslationTable.scala
@@ -1,0 +1,27 @@
+package io.scalac.tezos.translator.schema
+
+import io.scalac.tezos.translator.model.{Translation, TranslationDomainModel}
+import org.joda.time.DateTime
+import slick.jdbc.MySQLProfile.api._
+
+object TranslationTable {
+
+  val translations = TableQuery[TranslationTable]
+
+}
+
+class TranslationTable(tag: Tag) extends Table[TranslationDomainModel](tag, "translations") {
+
+  def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
+
+  def from = column[Translation.From]("from", O.SqlType("varchar(20)"))
+
+  def source = column[String]("source")
+
+  def translation = column[String]("translation")
+
+  def createdAt = column[DateTime]("created_at", slick.sql.SqlProfile.ColumnOption.NotNull, O.SqlType("TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)"))
+
+  def * = (id.?, from, source, translation, createdAt) <> (TranslationDomainModel.tupled, TranslationDomainModel.unapply)
+
+}

--- a/src/main/scala/io/scalac/tezos/translator/schema/package.scala
+++ b/src/main/scala/io/scalac/tezos/translator/schema/package.scala
@@ -1,0 +1,23 @@
+package io.scalac.tezos.translator
+
+import java.sql.Timestamp
+
+import io.scalac.tezos.translator.model.Translation
+import org.joda.time.DateTime
+import slick.jdbc.MySQLProfile.api._
+
+package object schema {
+
+  implicit val datetimeColumnType = MappedColumnType.base[DateTime, Timestamp](
+    dt => new Timestamp(dt.toDate.getTime),
+    ts => new DateTime(ts)
+  )
+
+  implicit val translationFromColumnType =
+    MappedColumnType.base[Translation.From, String](
+      Translation.asString,
+      { x =>
+        Translation.fromString(x).getOrElse(throw new Exception("invalid translation format: " + x))
+      }
+    )
+}

--- a/src/test/scala/io/scalac/tezos/translator/DbTestBase.scala
+++ b/src/test/scala/io/scalac/tezos/translator/DbTestBase.scala
@@ -1,0 +1,38 @@
+package io.scalac.tezos.translator
+
+import io.scalac.tezos.translator.schema.TranslationTable
+import slick.dbio.{DBIOAction, NoStream}
+import slick.jdbc.JdbcBackend
+import slick.jdbc.MySQLProfile.api._
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait DbTestBase {
+
+  def testDb: JdbcBackend#Database
+
+  val dbTimeout: Duration = 5.seconds
+
+  protected def run[R](dbAction: DBIOAction[R, NoStream, Nothing]): R = Await.result(testDb.run(dbAction), dbTimeout)
+
+  protected def createTables(): Unit =
+    run(
+      DBIO.sequence(
+        Seq(
+          TranslationTable.translations.schema.create
+        )
+      )
+    )
+
+  protected def dropTables() = run {
+    TranslationTable.translations.schema.dropIfExists
+  }
+
+  protected def recreateTables(): Unit = {
+    dropTables()
+    createTables()
+  }
+
+}

--- a/src/test/scala/io/scalac/tezos/translator/HistoryTest.scala
+++ b/src/test/scala/io/scalac/tezos/translator/HistoryTest.scala
@@ -1,0 +1,125 @@
+package io.scalac.tezos.translator
+
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import io.scalac.tezos.translator.micheline.MichelineTranslator
+import io.scalac.tezos.translator.model.HistoryViewModel
+import io.scalac.tezos.translator.routes.JsonSupport
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+class HistoryTest extends FlatSpec with Matchers with ScalatestRouteTest with JsonSupport with BeforeAndAfterAll {
+
+  val routes = new Routes(new TranslationsService).allRoutes
+
+  override def beforeAll() = {
+    translateMicheline(Samples.micheline)
+    translateMichelson(Samples.michelson)
+    translateMichelson(Samples.micheline, StatusCodes.BadRequest)
+    translateMicheline(Samples.micheline)
+  }
+
+  val michelsonTranslation = // WORKAROUND: translation is formatted differently than the source
+    MichelineTranslator
+      .michelsonToMicheline(Samples.michelson)
+      .getOrElse("Something goes wrong")
+
+  "A History" should "return translations history" in {
+    Get("/v1/translations") ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+
+      val history = responseAs[List[HistoryViewModel]]
+      history should have size 3
+
+      val expectedSources = List(Samples.micheline, Samples.michelson, Samples.micheline)
+      val expectedTranslations = List(Samples.michelson, michelsonTranslation, Samples.michelson)
+
+      history.map(_.source) shouldBe expectedSources
+      history.map(_.translation) shouldBe expectedTranslations
+    }
+  }
+
+  it should "fails for unknown source" in {
+    Get("/v1/translations?source=lorem") ~> Route.seal(routes) ~> check {
+      status shouldBe StatusCodes.BadRequest
+      responseAs[String] shouldBe "The query parameter 'source' was malformed:\n'lorem' is not a valid `source` value"
+    }
+  }
+
+  it should "return only micheline to michelson translations" in {
+    Get("/v1/translations?source=micheline") ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+      val history = responseAs[List[HistoryViewModel]]
+      history should have size 2
+
+      val expectedSources = List(Samples.micheline, Samples.micheline)
+      val expectedTranslations = List(Samples.michelson, Samples.michelson)
+
+      history.map(_.source) shouldBe expectedSources
+      history.map(_.translation) shouldBe expectedTranslations
+    }
+  }
+
+  it should "return only michelson to micheline translations" in {
+    Get("/v1/translations?source=michelson") ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+      val history = responseAs[List[HistoryViewModel]]
+      history should have size 1
+
+      history.map(_.source) shouldBe List(Samples.michelson)
+      history.map(_.translation) shouldBe List(michelsonTranslation)
+    }
+  }
+
+  it should "return only 10 history entries" in {
+    (1 to 10) foreach { _ =>
+      translateMichelson(Samples.michelson)
+      translateMicheline(Samples.micheline)
+    }
+    Get("/v1/translations") ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+      val history = responseAs[List[HistoryViewModel]]
+      history should have size 10
+
+      val expectedSources = Set(Samples.micheline, Samples.michelson)
+      history.map(_.source).toSet shouldBe expectedSources
+    }
+  }
+
+  it should "return only 10 history entries filtered by micheline" in {
+    (1 to 10) foreach { _ =>
+      translateMichelson(Samples.michelson)
+      translateMicheline(Samples.micheline)
+    }
+    Get("/v1/translations?source=micheline") ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+      val history = responseAs[List[HistoryViewModel]]
+      history should have size 10
+      history.map(_.source).toSet shouldBe Set(Samples.micheline)
+    }
+  }
+
+  it should "return only 10 history entries filtered by michelson" in {
+    (1 to 10) foreach { _ =>
+      translateMichelson(Samples.michelson)
+      translateMicheline(Samples.micheline)
+    }
+    Get("/v1/translations?source=michelson") ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+      val history = responseAs[List[HistoryViewModel]]
+      history should have size 10
+
+      history.map(_.source).toSet shouldBe Set(Samples.michelson)
+    }
+  }
+
+  private def translateMicheline(micheline: String) =
+    Post("/v1/translate/from/micheline/to/michelson", micheline) ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+    }
+
+  private def translateMichelson(michelson: String, statusCode: StatusCode = StatusCodes.OK) =
+    Post("/v1/translate/from/michelson/to/micheline", michelson) ~> routes ~> check {
+      status shouldBe statusCode
+    }
+}

--- a/src/test/scala/io/scalac/tezos/translator/HistoryTest.scala
+++ b/src/test/scala/io/scalac/tezos/translator/HistoryTest.scala
@@ -1,38 +1,48 @@
 package io.scalac.tezos.translator
 
-import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import io.scalac.tezos.translator.micheline.MichelineTranslator
-import io.scalac.tezos.translator.model.HistoryViewModel
+import io.scalac.tezos.translator.model.{HistoryViewModel, Translation, TranslationDomainModel}
 import io.scalac.tezos.translator.routes.JsonSupport
+import io.scalac.tezos.translator.schema.TranslationTable
+import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import slick.jdbc.MySQLProfile.api._
 
-class HistoryTest extends FlatSpec with Matchers with ScalatestRouteTest with JsonSupport with BeforeAndAfterAll {
+class HistoryTest extends FlatSpec with Matchers with ScalatestRouteTest with JsonSupport with BeforeAndAfterAll with DbTestBase {
 
-  val routes = new Routes(new TranslationsService).allRoutes
+  implicit val repository = new TranslationRepository
+
+  implicit val testDb = Database.forConfig("tezos-db")
+
+  private val service = new TranslationsService
+  val routes = new Routes(service).allRoutes
 
   override def beforeAll() = {
-    translateMicheline(Samples.micheline)
-    translateMichelson(Samples.michelson)
-    translateMichelson(Samples.micheline, StatusCodes.BadRequest)
-    translateMicheline(Samples.micheline)
+    recreateTables()
+    (1 to 100) foreach { i =>
+      addMichelineTranslation(s"from micheline $i", s"to michelson $i")
+      addMichelsonTranslation(s"from michelson $i", s"to micheline $i")
+    }
   }
 
-  val michelsonTranslation = // WORKAROUND: translation is formatted differently than the source
-    MichelineTranslator
-      .michelsonToMicheline(Samples.michelson)
-      .getOrElse("Something goes wrong")
+  override def afterAll() = {
+    super.afterAll()
+    testDb.close()
+  }
 
-  "A History" should "return translations history" in {
+  "A History" should "return 10 mixed translations if query parameters not specified" in {
     Get("/v1/translations") ~> routes ~> check {
       status shouldBe StatusCodes.OK
 
       val history = responseAs[List[HistoryViewModel]]
-      history should have size 3
+      history should have size 10
 
-      val expectedSources = List(Samples.micheline, Samples.michelson, Samples.micheline)
-      val expectedTranslations = List(Samples.michelson, michelsonTranslation, Samples.michelson)
+      val expectedSources = List("from michelson 100", "from micheline 100", "from michelson 99", "from micheline 99",
+        "from michelson 98", "from micheline 98", "from michelson 97", "from micheline 97", "from michelson 96", "from micheline 96")
+      val expectedTranslations = List("to micheline 100", "to michelson 100", "to micheline 99", "to michelson 99",
+        "to micheline 98", "to michelson 98", "to micheline 97", "to michelson 97", "to micheline 96", "to michelson 96")
 
       history.map(_.source) shouldBe expectedSources
       history.map(_.translation) shouldBe expectedTranslations
@@ -50,10 +60,12 @@ class HistoryTest extends FlatSpec with Matchers with ScalatestRouteTest with Js
     Get("/v1/translations?source=micheline") ~> routes ~> check {
       status shouldBe StatusCodes.OK
       val history = responseAs[List[HistoryViewModel]]
-      history should have size 2
+      history should have size 10
 
-      val expectedSources = List(Samples.micheline, Samples.micheline)
-      val expectedTranslations = List(Samples.michelson, Samples.michelson)
+      val expectedSources = List("from micheline 100", "from micheline 99", "from micheline 98", "from micheline 97",
+        "from micheline 96", "from micheline 95", "from micheline 94", "from micheline 93", "from micheline 92", "from micheline 91")
+      val expectedTranslations = List("to michelson 100", "to michelson 99", "to michelson 98", "to michelson 97",
+        "to michelson 96", "to michelson 95", "to michelson 94", "to michelson 93", "to michelson 92", "to michelson 91")
 
       history.map(_.source) shouldBe expectedSources
       history.map(_.translation) shouldBe expectedTranslations
@@ -64,62 +76,50 @@ class HistoryTest extends FlatSpec with Matchers with ScalatestRouteTest with Js
     Get("/v1/translations?source=michelson") ~> routes ~> check {
       status shouldBe StatusCodes.OK
       val history = responseAs[List[HistoryViewModel]]
-      history should have size 1
-
-      history.map(_.source) shouldBe List(Samples.michelson)
-      history.map(_.translation) shouldBe List(michelsonTranslation)
-    }
-  }
-
-  it should "return only 10 history entries" in {
-    (1 to 10) foreach { _ =>
-      translateMichelson(Samples.michelson)
-      translateMicheline(Samples.micheline)
-    }
-    Get("/v1/translations") ~> routes ~> check {
-      status shouldBe StatusCodes.OK
-      val history = responseAs[List[HistoryViewModel]]
       history should have size 10
 
-      val expectedSources = Set(Samples.micheline, Samples.michelson)
-      history.map(_.source).toSet shouldBe expectedSources
+      val expectedSources = List("from michelson 100", "from michelson 99", "from michelson 98", "from michelson 97",
+        "from michelson 96", "from michelson 95", "from michelson 94", "from michelson 93", "from michelson 92", "from michelson 91")
+
+      history.map(_.source) shouldBe expectedSources
     }
   }
 
-  it should "return only 10 history entries filtered by micheline" in {
-    (1 to 10) foreach { _ =>
-      translateMichelson(Samples.michelson)
-      translateMicheline(Samples.micheline)
-    }
-    Get("/v1/translations?source=micheline") ~> routes ~> check {
+  it should "return limited history entries filtered by micheline" in {
+    Get("/v1/translations?source=micheline&limit=3") ~> routes ~> check {
       status shouldBe StatusCodes.OK
       val history = responseAs[List[HistoryViewModel]]
-      history should have size 10
-      history.map(_.source).toSet shouldBe Set(Samples.micheline)
+      history should have size 3
+
+      val expectedSources = List("from micheline 100", "from micheline 99", "from micheline 98")
+      val expectedTranslations = List("to michelson 100", "to michelson 99", "to michelson 98")
+
+      history.map(_.source) shouldBe expectedSources
+      history.map(_.translation) shouldBe expectedTranslations
     }
   }
 
-  it should "return only 10 history entries filtered by michelson" in {
-    (1 to 10) foreach { _ =>
-      translateMichelson(Samples.michelson)
-      translateMicheline(Samples.micheline)
-    }
-    Get("/v1/translations?source=michelson") ~> routes ~> check {
+  it should "return limited history entries filtered by michelson" in {
+    Get("/v1/translations?source=michelson&limit=3") ~> routes ~> check {
       status shouldBe StatusCodes.OK
       val history = responseAs[List[HistoryViewModel]]
-      history should have size 10
+      history should have size 3
 
-      history.map(_.source).toSet shouldBe Set(Samples.michelson)
+      val expectedSources = List("from michelson 100", "from michelson 99", "from michelson 98")
+      val expectedTranslations = List("to micheline 100", "to micheline 99", "to micheline 98")
+
+      history.map(_.source) shouldBe expectedSources
+      history.map(_.translation) shouldBe expectedTranslations
     }
   }
 
-  private def translateMicheline(micheline: String) =
-    Post("/v1/translate/from/micheline/to/michelson", micheline) ~> routes ~> check {
-      status shouldBe StatusCodes.OK
-    }
+  private val addMichelineTranslation = addTranslation(Translation.FromMicheline, _, _)
 
-  private def translateMichelson(michelson: String, statusCode: StatusCode = StatusCodes.OK) =
-    Post("/v1/translate/from/michelson/to/micheline", michelson) ~> routes ~> check {
-      status shouldBe statusCode
-    }
+  private val addMichelsonTranslation = addTranslation(Translation.FromMichelson, _, _)
+
+  private def addTranslation(from: Translation.From, source: String, translation: String) =
+    run(
+      TranslationTable.translations += TranslationDomainModel(id = None, from, source, translation, createdAt = DateTime.now)
+    )
+
 }

--- a/src/test/scala/io/scalac/tezos/translator/TranslationTest.scala
+++ b/src/test/scala/io/scalac/tezos/translator/TranslationTest.scala
@@ -2,33 +2,31 @@ package io.scalac.tezos.translator
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import io.circe._, io.circe.parser._
-import io.circe._
 import io.circe.parser._
 import org.scalatest.{MustMatchers, WordSpec}
 import org.scalatest.concurrent.ScalaFutures
 
-class RoutesTest extends WordSpec with MustMatchers with ScalaFutures with ScalatestRouteTest {
+class TranslationTest extends WordSpec with MustMatchers with ScalaFutures with ScalatestRouteTest {
 
-  val route = Routes.route
+  val routes = new Routes(new TranslationsService).allRoutes
 
   "A Routes" can {
     "translate michelson to micheline" when {
       "michelson is correct" in {
-        Post("/v1/translate/from/michelson/to/micheline", Samples.michelson) ~> route ~> check {
+        Post("/v1/translate/from/michelson/to/micheline", Samples.michelson) ~> routes ~> check {
           status must equal(StatusCodes.OK)
           parse(responseAs[String]) mustEqual parse(Samples.micheline)
         }
       }
 
       "michelson in incorrect 1" in {
-        Post("/v1/translate/from/michelson/to/micheline", Samples.incorrectMichelson1) ~> route ~> check {
+        Post("/v1/translate/from/michelson/to/micheline", Samples.incorrectMichelson1) ~> routes ~> check {
           status must equal(StatusCodes.BadRequest)
         }
       }
 
       "michelson in incorrect 2" in {
-        Post("/v1/translate/from/michelson/to/micheline", Samples.incorrectMichelson1) ~> route ~> check {
+        Post("/v1/translate/from/michelson/to/micheline", Samples.incorrectMichelson1) ~> routes ~> check {
           status must equal(StatusCodes.BadRequest)
         }
       }
@@ -37,20 +35,20 @@ class RoutesTest extends WordSpec with MustMatchers with ScalaFutures with Scala
     "translate micheline to michelson" when {
 
       "micheline is correct" in {
-        Post("/v1/translate/from/micheline/to/michelson", Samples.micheline) ~> route ~> check {
+        Post("/v1/translate/from/micheline/to/michelson", Samples.micheline) ~> routes ~> check {
           status must equal(StatusCodes.OK)
           parse(responseAs[String]) mustEqual parse(Samples.michelson)
         }
       }
 
       "micheline is incorrect 1" in {
-        Post("/v1/translate/from/micheline/to/michelson", Samples.incorrectMicheline1) ~> route ~> check {
+        Post("/v1/translate/from/micheline/to/michelson", Samples.incorrectMicheline1) ~> routes ~> check {
           status must equal(StatusCodes.BadRequest)
         }
       }
 
       "micheline is incorrect 2" in {
-        Post("/v1/translate/from/micheline/to/michelson", Samples.incorrectMicheline2) ~> route ~> check {
+        Post("/v1/translate/from/micheline/to/michelson", Samples.incorrectMicheline2) ~> routes ~> check {
           status must equal(StatusCodes.BadRequest)
         }
       }

--- a/src/test/scala/io/scalac/tezos/translator/TranslationTest.scala
+++ b/src/test/scala/io/scalac/tezos/translator/TranslationTest.scala
@@ -5,10 +5,16 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import io.circe.parser._
 import org.scalatest.{MustMatchers, WordSpec}
 import org.scalatest.concurrent.ScalaFutures
+import slick.jdbc.MySQLProfile.api._
 
 class TranslationTest extends WordSpec with MustMatchers with ScalaFutures with ScalatestRouteTest {
 
-  val routes = new Routes(new TranslationsService).allRoutes
+  implicit val repository = new TranslationRepository
+
+  implicit val db = Database.forConfig("tezos-db")
+
+  private val service = new TranslationsService
+  val routes = new Routes(service).allRoutes
 
   "A Routes" can {
     "translate michelson to micheline" when {


### PR DESCRIPTION
New endpoint `GET /v1/translations` with optional parameter `source`