### PR TITLE
[feature/MMT-118] Extend the library API with contracts ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ TEZOS_DB_IP="127.0.0.1" \
 sbt run
 ```
 
+* Backend documentation is provided by Swagger and it is available at `$BE_URL/docs`
+
 ## Exemplary queries
 
 Backed is available at `localhost` at port `8080` if running without a container

--- a/src/it/scala/io/scalac/tezos/translator/SendEmailServiceSpec.scala
+++ b/src/it/scala/io/scalac/tezos/translator/SendEmailServiceSpec.scala
@@ -3,26 +3,27 @@ package io.scalac.tezos.translator
 import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
 import akka.testkit.TestKit
+import cats.syntax.option._
 import com.icegreen.greenmail.util.{ GreenMail, GreenMailUtil, ServerSetupTest }
 import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.refineMV
 import io.scalac.tezos.translator.config.{ CronConfiguration, EmailConfiguration }
 import io.scalac.tezos.translator.model.LibraryEntry.Accepted
 import io.scalac.tezos.translator.model.types.ContactData.{ Content, EmailReq, EmailS, Name, NameReq, Phone, PhoneReq }
+import io.scalac.tezos.translator.model.types.Library.{ Author, Description, Micheline, Michelson, NotEmptyAndNotLong, Title }
 import io.scalac.tezos.translator.model.{ EmailAddress, SendEmail }
 import io.scalac.tezos.translator.repository.Emails2SendRepository
-import io.scalac.tezos.translator.routes.dto.{ LibraryEntryRoutesDto, SendEmailRoutesDto }
+import io.scalac.tezos.translator.routes.dto.{ LibraryEntryRoutesNewDto, SendEmailRoutesDto }
 import io.scalac.tezos.translator.service.{ Emails2SendService, SendEmailsServiceImpl }
 import javax.mail.internet.MimeMessage
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, FlatSpecLike, Matchers }
-import eu.timepit.refined.refineMV
-import io.scalac.tezos.translator.model.types.Library.{ Author, Description, Micheline, Michelson, NotEmptyAndNotLong, Title }
-import cats.syntax.option._
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.Success
 import scala.language.postfixOps
+import scala.util.Success
 
 //noinspection TypeAnnotation
 class SendEmailServiceSpec
@@ -202,7 +203,7 @@ class SendEmailServiceSpec
       .get
 
     val e3: SendEmail = SendEmail.approvalRequest(
-       LibraryEntryRoutesDto(
+       LibraryEntryRoutesNewDto(
           Title(refineMV[NotEmptyAndNotLong]("contract name")),
           Author(refineMV[NotEmptyAndNotLong]("Thanos")).some,
           None,

--- a/src/main/scala/io/scalac/tezos/translator/Boot.scala
+++ b/src/main/scala/io/scalac/tezos/translator/Boot.scala
@@ -81,7 +81,7 @@ object Boot {
           cronEmailSender.cancel()
           binding.unbind()
         case Failure(ex) =>
-          Future(log.error(ex, s"An error was occurred !"))
+          Future(log.error(ex, s"An error has occurred!"))
       }
       .onComplete(_ => system.terminate())
   }

--- a/src/main/scala/io/scalac/tezos/translator/model/SendEmail.scala
+++ b/src/main/scala/io/scalac/tezos/translator/model/SendEmail.scala
@@ -2,10 +2,9 @@ package io.scalac.tezos.translator.model
 
 import io.scalac.tezos.translator.model.LibraryEntry.Status
 import io.scalac.tezos.translator.model.types.Library.Title
-import io.scalac.tezos.translator.model.types.UUIDs.SendEmailId
-import io.scalac.tezos.translator.model.types.UUIDs.generateSendEmailId
+import io.scalac.tezos.translator.model.types.UUIDs.{ generateSendEmailId, SendEmailId }
 import io.scalac.tezos.translator.repository.dto.SendEmailDbDto
-import io.scalac.tezos.translator.routes.dto.{ LibraryEntryRoutesDto, SendEmailRoutesDto }
+import io.scalac.tezos.translator.routes.dto.{ LibraryEntryRoutesNewDto, SendEmailRoutesDto }
 
 import scala.util.{ Success, Try }
 
@@ -17,7 +16,7 @@ sealed abstract case class SendEmail(
 
 object SendEmail {
 
-  def approvalRequest(libraryDto: LibraryEntryRoutesDto, adminEmail: EmailAddress): SendEmail = {
+  def approvalRequest(libraryDto: LibraryEntryRoutesNewDto, adminEmail: EmailAddress): SendEmail = {
     val uid     = generateSendEmailId
     val subject = "Library approval request"
     val message = TextContent {

--- a/src/main/scala/io/scalac/tezos/translator/routes/Endpoints.scala
+++ b/src/main/scala/io/scalac/tezos/translator/routes/Endpoints.scala
@@ -47,8 +47,8 @@ object Endpoints {
   val limitQuery: EndpointInput.Query[Option[Limit]] =
     query[Option[Limit]](limit).description("Limit")
 
-  val uidQuery: EndpointInput.Query[UUIDString] =
-    query[UUIDString]("uid").description("Uid").example(refineMV[Uuid]("8682fcd8-b73d-48fa-abdc-3a2b9093b1f2"))
+  val uidPath: EndpointInput.PathCapture[UUIDString] =
+    path[UUIDString]("entryId").description("UUID of related entry").example(refineMV[Uuid]("8682fcd8-b73d-48fa-abdc-3a2b9093b1f2"))
 
   val statusQuery: EndpointInput.Query[String] =
     query[String]("status").description("Desired status").example("accepted")

--- a/src/main/scala/io/scalac/tezos/translator/routes/LibraryRoutes.scala
+++ b/src/main/scala/io/scalac/tezos/translator/routes/LibraryRoutes.scala
@@ -3,24 +3,24 @@ package io.scalac.tezos.translator.routes
 import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.server.Route
+import cats.syntax.either._
 import io.scalac.tezos.translator.config.CaptchaConfig
 import io.scalac.tezos.translator.model.LibraryEntry.{ Accepted, PendingApproval, Status }
-import io.scalac.tezos.translator.model.{ AuthUserData, EmailAddress, SendEmail }
-import io.scalac.tezos.translator.routes.dto.DTOValidation
-import io.scalac.tezos.translator.routes.dto.DTO.Error
-import io.scalac.tezos.translator.routes.utils.ReCaptcha._
-import io.scalac.tezos.translator.routes.dto.{ LibraryEntryDTO, LibraryEntryRoutesAdminDto, LibraryEntryRoutesDto }
-import io.scalac.tezos.translator.routes.dto.LibraryEntryDTO._
+import io.scalac.tezos.translator.model.types.Auth.{ Captcha, UserToken }
+import io.scalac.tezos.translator.model.types.Params._
 import io.scalac.tezos.translator.model.types.UUIDs.{ LibraryEntryId, UUIDString }
+import io.scalac.tezos.translator.model.{ AuthUserData, EmailAddress, SendEmail }
+import io.scalac.tezos.translator.routes.Endpoints._
+import io.scalac.tezos.translator.routes.dto.DTO.Error
+import io.scalac.tezos.translator.routes.dto.LibraryEntryDTO._
+import io.scalac.tezos.translator.routes.dto._
+import io.scalac.tezos.translator.routes.utils.ReCaptcha._
 import io.scalac.tezos.translator.service.{ Emails2SendService, LibraryService, UserService }
 import sttp.model.StatusCode
 import sttp.tapir._
 import sttp.tapir.json.circe._
 import sttp.tapir.server.akkahttp._
-import cats.syntax.either._
-import io.scalac.tezos.translator.routes.Endpoints._
-import io.scalac.tezos.translator.model.types.Auth.{ Captcha, UserToken }
-import io.scalac.tezos.translator.model.types.Params._
+
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
 
@@ -38,16 +38,28 @@ class LibraryRoutes(
 
   private val libraryCaptchaEndpoint: Endpoint[Option[Captcha], ErrorResponse, Unit, Nothing] =
     Endpoints.captchaEndpoint(captchaConfig).in("library")
-  private val libraryEndpoint: Endpoint[Unit, Unit, Unit, Nothing] = Endpoints.baseEndpoint.in("library")
+  private val libraryEndpoint             = Endpoints.baseEndpoint.in("library")
+  private val libraryEntryEndpoint        = libraryEndpoint.in(uidPath)
+  private val librarySecuredEntryEndpoint = libraryEndpoint.in(auth.bearer).in(uidPath)
 
-  private val libraryAddEndpoint: Endpoint[(Option[Captcha], LibraryEntryRoutesDto), ErrorResponse, StatusCode, Nothing] =
+  private def handleError(t: Throwable): ErrorResponse =
+    t match {
+      case _: IllegalArgumentException => (Error(t.getMessage), StatusCode.NotFound)
+      case _                           => (Error("Can't update"), StatusCode.InternalServerError)
+    }
+
+  /** Endpoints **/
+  override def docs = List(addEntryEndpoint, getAllEntriesEndpoint, getSingleEntryEndpoint, putEntryEndpoint, deleteEntryEndpoint)
+
+  private val addEntryEndpoint: Endpoint[(Option[Captcha], LibraryEntryRoutesNewDto), ErrorResponse, StatusCode, Nothing] =
     libraryCaptchaEndpoint
-      .in(jsonBody[LibraryEntryRoutesDto])
+      .in(jsonBody[LibraryEntryRoutesNewDto])
       .post
       .out(statusCode)
-      .description("Will add LibraryEntryRoutesDto to storage")
+      .description("Will add LibraryEntryRoutesNewDto to storage")
 
-  private val getDtoEndpoint: Endpoint[(Option[UserToken], Option[Offset], Option[Limit]), ErrorResponse, Seq[LibraryEntryDTO], Nothing] =
+  private val getAllEntriesEndpoint
+     : Endpoint[(Option[UserToken], Option[Offset], Option[Limit]), ErrorResponse, Seq[LibraryEntryDTO], Nothing] =
     libraryEndpoint
       .in(maybeAuthHeader)
       .in(offsetQuery.and(limitQuery))
@@ -56,37 +68,45 @@ class LibraryRoutes(
       .get
       .description("Will return sequence of LibraryEntryRoutesDto or LibraryEntryRoutesAdminDto if auth header provided")
 
+  private val getSingleEntryEndpoint: Endpoint[(UUIDString, Option[UserToken]), ErrorResponse, LibraryEntryDTO, Nothing] =
+    libraryEntryEndpoint
+      .in(maybeAuthHeader)
+      .errorOut(errorResponse)
+      .out(jsonBody[LibraryEntryDTO])
+      .get
+      .description("Will return LibraryEntryRoutesDto with given UUID or LibraryEntryRoutesAdminDto if auth header provided")
+
   private val putEntryEndpoint: Endpoint[(String, UUIDString, String), ErrorResponse, StatusCode, Nothing] =
-    libraryEndpoint
-      .in(auth.bearer)
-      .in(uidQuery.and(statusQuery))
+    librarySecuredEntryEndpoint
+      .in(statusQuery)
       .errorOut(errorResponse)
       .out(statusCode)
       .put
-      .description("Will change the status of entry with passed uid")
+      .description("Will change the status of entry with passed UUID")
 
   private val deleteEntryEndpoint: Endpoint[(String, UUIDString), ErrorResponse, StatusCode, Nothing] =
-    libraryEndpoint
-      .in(auth.bearer)
-      .in(uidQuery)
+    librarySecuredEntryEndpoint
       .errorOut(errorResponse)
       .out(statusCode)
       .delete
-      .description("Will delete an entry with passed uid")
+      .description("Will delete an entry with passed UUID")
 
-  override def routes: Route = addNewEntryRoute ~ getDTORoute ~ putEntryRoute ~ deleteEntryRoute
+  /** Routes **/
+  override def routes = addEntryRoute ~ getSingleEntryRoute ~ getAllEntriesRoute ~ putEntryRoute ~ deleteEntryRoute
 
-  private def addNewEntryRoute(): Route =
-    libraryAddEndpoint.toRoute {
+  /** Routes :: Add entry **/
+
+  private def addEntryRoute: Route =
+    addEntryEndpoint.toRoute {
       (withReCaptchaVerify(_, log, captchaConfig))
-        .andThenFirstE { t: (Unit, LibraryEntryRoutesDto) => DTOValidation.validateDto(t._2) }
-        .andThenFirstE(addNewEntry)
+        .andThenFirstE { t: (Unit, LibraryEntryRoutesNewDto) => DTOValidation.validateDto(t._2) }
+        .andThenFirstE(addEntry)
     }
 
-  private def addNewEntry(libraryDTO: LibraryEntryRoutesDto): Future[Either[ErrorResponse, StatusCode]] = {
-    val sendEmailF = libraryDTO.email match {
+  private def addEntry(newEntry: LibraryEntryRoutesNewDto): Future[Either[ErrorResponse, StatusCode]] = {
+    val sendEmailF = newEntry.email match {
       case Some(_) =>
-        val e = SendEmail.approvalRequest(libraryDTO, adminEmail)
+        val e = SendEmail.approvalRequest(newEntry, adminEmail)
         emails2SendService
           .addNewEmail2Send(e)
           .recover {
@@ -99,34 +119,39 @@ class LibraryRoutes(
     }
 
     val operationPerformed = for {
-      entry     <- Future.fromTry(libraryDTO.toDomain)
+      entry     <- Future.fromTry(newEntry.toDomain)
       addResult <- service.addNew(entry)
       _         <- sendEmailF
     } yield addResult
     operationPerformed.map(_ => StatusCode.Ok.asRight).recover {
       case e =>
-        log.error(s"Can't save library dto $libraryDTO, error - $e")
+        log.error(s"Can't save library dto $newEntry, error - $e")
         (Error("Can't save payload"), StatusCode.InternalServerError).asLeft
     }
   }
 
-  private def getDTORoute: Route =
-    getDtoEndpoint.toRoute {
-      (getDto _).tupled
+  /** Routes :: Get all entries **/
+
+  private def getAllEntriesRoute: Route =
+    getAllEntriesEndpoint.toRoute {
+      (getAllEntries _).tupled
     }
 
-  private def getDto(
+  private def getAllEntries(
      maybeToken: Option[UserToken],
      maybeOffset: Option[Offset],
      maybeLimit: Option[Limit]
    ): Future[Either[ErrorResponse, Seq[LibraryEntryDTO]]] =
     maybeToken
-      .withMaybeAuth(userService)(getAdminsDto(maybeOffset, maybeLimit))(getJustDto(maybeOffset, maybeLimit))
+      .withMaybeAuth(userService)(getEntriesForAdmin(maybeOffset, maybeLimit))(getEntries(maybeOffset, maybeLimit))
       .value
 
-  private def getAdminsDto(maybeOffset: Option[Offset], maybeLimit: Option[Limit]): Future[Either[ErrorResponse, Seq[LibraryEntryDTO]]] =
+  private def getEntriesForAdmin(
+     maybeOffset: Option[Offset],
+     maybeLimit: Option[Limit]
+   ): Future[Either[ErrorResponse, Seq[LibraryEntryDTO]]] =
     service
-      .getRecords(maybeOffset, maybeLimit)
+      .getEntries(maybeOffset, maybeLimit)
       .map(_.map(LibraryEntryRoutesAdminDto.fromDomain).asRight)
       .recover {
         case e =>
@@ -134,9 +159,9 @@ class LibraryRoutes(
           (Error("Can't get records"), StatusCode.InternalServerError).asLeft
       }
 
-  private def getJustDto(maybeOffset: Option[Offset], maybeLimit: Option[Limit]): Future[Either[ErrorResponse, Seq[LibraryEntryDTO]]] =
+  private def getEntries(maybeOffset: Option[Offset], maybeLimit: Option[Limit]): Future[Either[ErrorResponse, Seq[LibraryEntryDTO]]] =
     service
-      .getRecords(maybeOffset, maybeLimit, Some(Accepted))
+      .getEntries(maybeOffset, maybeLimit, Some(Accepted))
       .map(_.map(LibraryEntryRoutesDto.fromDomain).asRight)
       .recover {
         case e =>
@@ -144,22 +169,59 @@ class LibraryRoutes(
           (Error("Can't get records"), StatusCode.InternalServerError).asLeft
       }
 
+  /** Routes :: Get single entry **/
+
+  private def getSingleEntryRoute: Route =
+    getSingleEntryEndpoint.toRoute {
+      (getSingleEntry _).tupled
+    }
+
+  private def getSingleEntry(uid: UUIDString, maybeToken: Option[UserToken]): Future[Either[ErrorResponse, LibraryEntryDTO]] =
+    maybeToken
+      .withMaybeAuth(userService)(getEntryForAdmin(uid))(getEntry(uid))
+      .value
+
+  private def getEntryForAdmin(uid: UUIDString): Future[Either[ErrorResponse, LibraryEntryDTO]] =
+    service
+      .getEntry(LibraryEntryId(uid))
+      .map(LibraryEntryRoutesAdminDto.fromDomain)
+      .map(_.asRight)
+      .recover {
+        case e =>
+          log.error(s"Can't show accepted library model, uid: $uid, error - $e")
+          handleError(e).asLeft
+      }
+
+  private def getEntry(uid: UUIDString): Future[Either[ErrorResponse, LibraryEntryDTO]] =
+    service
+      .getEntryWithOptionalFilter(LibraryEntryId(uid), Some(Accepted))
+      .map(LibraryEntryRoutesDto.fromDomain)
+      .map(_.asRight)
+      .recover {
+        case e =>
+          log.error(s"Can't show accepted library model, uid: $uid, error - $e")
+          handleError(e).asLeft
+      }
+
+  /** Routes :: Put entry **/
+
   private def putEntryRoute: Route =
     putEntryEndpoint.toRoute {
       (bearer2TokenF _)
         .andThenFirstE(userService.authenticate)
-        .andThenFirstE { args: (AuthUserData, UUIDString, String) => putDto(args._2, args._3) }
+        .andThenFirstE { args: (AuthUserData, UUIDString, String) => putEntry(args._2, args._3) }
     }
 
-  private def putDto(uid: UUIDString, status: String): Future[Either[ErrorResponse, StatusCode]] = {
+  private def putEntry(uid: UUIDString, status: String): Future[Either[ErrorResponse, StatusCode]] = {
     val statusChangeWithEmail =
       for {
         s <- Future.fromTry(Status.fromString(status) match {
               case Success(PendingApproval) =>
-                Failure(new IllegalArgumentException("Cannot change status to 'pending_approval' !"))
+                Failure(new IllegalArgumentException("Cannot change status to 'pending_approval'!"))
               case other => other
             })
-        u            = LibraryEntryId(uid)
+        u = LibraryEntryId(uid)
+
         updatedEntry <- service.changeStatus(u, s)
         _ <- updatedEntry.email match {
               case Some(email) =>
@@ -177,20 +239,16 @@ class LibraryRoutes(
     }
   }
 
-  private def handleError(t: Throwable): ErrorResponse =
-    t match {
-      case _: IllegalArgumentException => (Error(t.getMessage), StatusCode.NotFound)
-      case _                           => (Error("Can't update"), StatusCode.InternalServerError)
-    }
+  /** Routes :: Delete entry **/
 
   private def deleteEntryRoute: Route =
     deleteEntryEndpoint.toRoute {
       (bearer2TokenF _)
         .andThenFirstE(userService.authenticate)
-        .andThenFirstE { args: (AuthUserData, UUIDString) => deleteDto(args._2) }
+        .andThenFirstE { args: (AuthUserData, UUIDString) => deleteEntry(args._2) }
     }
 
-  private def deleteDto(uid: UUIDString): Future[Either[ErrorResponse, StatusCode]] =
+  private def deleteEntry(uid: UUIDString): Future[Either[ErrorResponse, StatusCode]] =
     service
       .delete(LibraryEntryId(uid))
       .map(_ => StatusCode.Ok.asRight)
@@ -199,8 +257,5 @@ class LibraryRoutes(
           log.error(s"Can't delete library entry, uid: $uid, error - $e")
           handleError(e).asLeft
       }
-
-  override def docs: List[Endpoint[_, _, _, _]] =
-    List(libraryAddEndpoint, getDtoEndpoint, putEntryEndpoint, deleteEntryEndpoint)
 
 }

--- a/src/main/scala/io/scalac/tezos/translator/routes/LoginRoutes.scala
+++ b/src/main/scala/io/scalac/tezos/translator/routes/LoginRoutes.scala
@@ -39,7 +39,7 @@ class LoginRoutes(userService: UserService)(implicit ec: ExecutionContext) exten
   def loginLogic(credentials: UserCredentials): Future[Either[ErrorResponse, String]] =
     userService.authenticateAndCreateToken(credentials.username, credentials.password).map {
       case Some(token) => Right(token.v.value)
-      case None        => (Error("Wrong credentials !"), StatusCode.Forbidden).asLeft
+      case None        => (Error("Wrong credentials!"), StatusCode.Forbidden).asLeft
     }
 
   def logoutLogic(token: UserToken): Future[Either[ErrorResponse, Unit]] =

--- a/src/main/scala/io/scalac/tezos/translator/routes/dto/DTOValidation.scala
+++ b/src/main/scala/io/scalac/tezos/translator/routes/dto/DTOValidation.scala
@@ -1,18 +1,19 @@
 package io.scalac.tezos.translator.routes.dto
 
 import cats.data.NonEmptyList
-import cats.instances.parallel._
-import cats.instances.option._
 import cats.instances.either._
-import cats.syntax.traverse._
+import cats.instances.option._
+import cats.instances.parallel._
 import cats.syntax.either._
 import cats.syntax.parallel._
+import cats.syntax.traverse._
 import eu.timepit.refined.refineV
 import io.scalac.tezos.translator.model._
 import io.scalac.tezos.translator.model.types.ContactData.{ EmailReq, EmailS }
 import io.scalac.tezos.translator.routes.dto.DTO.{ ErrorDTO, Errors }
 import io.scalac.tezos.translator.routes.dto.DTOValidation.ValidationResult
 import sttp.model.StatusCode
+
 import scala.concurrent.{ ExecutionContext, Future }
 
 trait DTOValidation[T] {
@@ -101,7 +102,7 @@ object DTOValidation {
            }
       )
 
-  def validateLibraryEntryRoutesDto: LibraryEntryRoutesDto => ValidationResult[LibraryEntryRoutesDto] = { dto =>
+  def validateLibraryEntryRoutesNewDto: LibraryEntryRoutesNewDto => ValidationResult[LibraryEntryRoutesNewDto] = { dto =>
     val checkEmail: Either[NonEmptyList[DTOValidationError], Option[EmailS]] =
       dto.email.traverse(checkEmailIsValid)
 
@@ -116,7 +117,7 @@ object DTOValidation {
 
   final case class FieldIsEmpty(field: String) extends DTOValidationError
 
-  implicit val LibraryDTOValidation: DTOValidation[LibraryEntryRoutesDto] = { dto => validateLibraryEntryRoutesDto(dto) }
+  implicit val LibraryDTOValidation: DTOValidation[LibraryEntryRoutesNewDto] = { dto => validateLibraryEntryRoutesNewDto(dto) }
 
   final case class FieldIsInvalid(fieldName: String, field: String) extends DTOValidationError
 

--- a/src/main/scala/io/scalac/tezos/translator/routes/dto/LibraryEntryDTO.scala
+++ b/src/main/scala/io/scalac/tezos/translator/routes/dto/LibraryEntryDTO.scala
@@ -1,28 +1,28 @@
 package io.scalac.tezos.translator.routes.dto
 
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import io.circe.{ Decoder, Encoder }
-import io.circe.generic.semiauto.deriveEncoder
-import io.circe.generic.semiauto.deriveDecoder
 import io.scalac.tezos.translator.model.LibraryEntry.PendingApproval
-import io.scalac.tezos.translator.model.types.ContactData.EmailS
-import io.scalac.tezos.translator.model.types.ContactData.MaybeEmailAddressOps
+import io.scalac.tezos.translator.model.types.ContactData.{ EmailS, MaybeEmailAddressOps }
+import io.scalac.tezos.translator.model.types.Library._
 import io.scalac.tezos.translator.model.types.UUIDs._
 import io.scalac.tezos.translator.model.{ EmailAddress, LibraryEntry }
+
 import scala.util.{ Success, Try }
-import io.scalac.tezos.translator.model.types.Library._
 
 sealed trait LibraryEntryDTO
 
 object LibraryEntryDTO {
 
   implicit val LibraryEntryDTOEncoder: Encoder[LibraryEntryDTO] = {
-    case v: LibraryEntryRoutesAdminDto =>
-      LibraryEntryRoutesAdminDto.libraryEntryRoutesAdminDtoEncoder(v)
-    case v: LibraryEntryRoutesDto =>
-      LibraryEntryRoutesDto.libraryEntryRoutesDtoEncoder(v)
+    case v: LibraryEntryRoutesAdminDto => LibraryEntryRoutesAdminDto.libraryEntryRoutesAdminDtoEncoder(v)
+    case v: LibraryEntryRoutesNewDto   => LibraryEntryRoutesNewDto.libraryEntryRoutesNewDtoEncoder(v)
+    case v: LibraryEntryRoutesDto      => LibraryEntryRoutesDto.libraryEntryRoutesDtoEncoder(v)
   }
 
 }
+
+/** LibraryEntryRoutesAdminDto **/
 
 case class LibraryEntryRoutesAdminDto(
    uid: LibraryEntryId,
@@ -57,7 +57,9 @@ object LibraryEntryRoutesAdminDto {
 
 }
 
-case class LibraryEntryRoutesDto(
+/** LibraryEntryRoutesNewDto **/
+
+case class LibraryEntryRoutesNewDto(
    title: Title,
    author: Option[Author],
    email: Option[EmailS],
@@ -89,10 +91,33 @@ case class LibraryEntryRoutesDto(
 
 }
 
+object LibraryEntryRoutesNewDto {
+
+  implicit val libraryEntryRoutesNewDtoEncoder: Encoder[LibraryEntryRoutesNewDto] =
+    deriveEncoder[LibraryEntryRoutesNewDto]
+
+  implicit val libraryEntryRoutesNewDtoDecoder: Decoder[LibraryEntryRoutesNewDto] =
+    deriveDecoder[LibraryEntryRoutesNewDto]
+
+}
+
+/** LibraryEntryRoutesDto **/
+
+case class LibraryEntryRoutesDto(
+   uid: LibraryEntryId,
+   title: Title,
+   author: Option[Author],
+   email: Option[EmailS],
+   description: Option[Description],
+   micheline: Micheline,
+   michelson: Michelson)
+    extends LibraryEntryDTO
+
 object LibraryEntryRoutesDto {
 
   def fromDomain(v: LibraryEntry): LibraryEntryRoutesDto =
     LibraryEntryRoutesDto(
+       uid         = v.uid,
        title       = v.title,
        author      = v.author,
        email       = v.email.toEmailS,

--- a/src/main/scala/io/scalac/tezos/translator/service/LibraryService.scala
+++ b/src/main/scala/io/scalac/tezos/translator/service/LibraryService.scala
@@ -1,8 +1,8 @@
 package io.scalac.tezos.translator.service
 
 import akka.event.LoggingAdapter
-import io.scalac.tezos.translator.model.LibraryEntry._
 import io.scalac.tezos.translator.model.LibraryEntry
+import io.scalac.tezos.translator.model.LibraryEntry._
 import io.scalac.tezos.translator.model.types.Params.{ Limit, Offset }
 import io.scalac.tezos.translator.model.types.UUIDs.LibraryEntryId
 import io.scalac.tezos.translator.repository.LibraryRepository
@@ -16,42 +16,65 @@ class LibraryService(repository: LibraryRepository, log: LoggingAdapter)(implici
   def addNew(entry: LibraryEntry): Future[Int] =
     repository.add(LibraryEntryDbDto.fromDomain(entry))
 
-  def getRecords(
+  def getEntry(id: LibraryEntryId): Future[LibraryEntry] =
+    for {
+      entryDb <- getEntryDb(id)
+      entry   <- entryDbToDomain(entryDb)
+    } yield entry
+
+  def getEntryWithOptionalFilter(id: LibraryEntryId, statusFilter: Option[Status] = None): Future[LibraryEntry] =
+    resolveAction {
+      for {
+        entry <- getEntry(id)
+      } yield {
+        statusFilter match {
+          case Some(s) => Some(entry).filter(_.status == s)
+          case None    => Some(entry)
+        }
+      }
+    }
+
+  def getEntries(
      offset: Option[Offset]       = None,
      limit: Option[Limit]         = None,
      statusFilter: Option[Status] = None
    ): Future[Seq[LibraryEntry]] =
     for {
-      entriesDto  <- repository.list(statusFilter, offset, limit)
-      entriesFSeq = entriesDto.map(e => Future.fromTry(e.toDomain))
-      entries     <- Future.sequence(entriesFSeq)
+      entriesDto <- repository.list(statusFilter, offset, limit)
+      entries    <- Future.sequence(entriesDto.map(e => Future.fromTry(e.toDomain)))
     } yield entries
 
-  def changeStatus(id: LibraryEntryId, newStatus: Status): Future[LibraryEntry] = {
-    val uidNotExistsException =
-      Future.failed(new IllegalArgumentException(s"Library Entry does not exist for uid: $id"))
-
+  def changeStatus(id: LibraryEntryId, newStatus: Status): Future[LibraryEntry] =
     for {
-      entry <- repository.get(id).flatMap {
-                case Some(v) => Future.successful(v)
-                case None    => uidNotExistsException
-              }
-      updatedDto <- repository.update(id, entry.copy(status = newStatus.value)).flatMap {
-                     case Some(v) => Future.successful(v)
-                     case None    => uidNotExistsException
-                   }
-      updated <- updatedDto.toDomain match {
-                  case Success(e) => Future.successful(e)
-                  case Failure(ex) =>
-                    log.error(s"Invalid library entry data in DB for uid: id ! ${ex.getMessage}")
-                    Future.failed(new IllegalStateException(s"Library entry for id has a wrong format in DB ! ${ex.getMessage}"))
-                }
+      entryDb    <- getEntryDb(id)
+      updatedDto <- resolveAction(repository.update(id, entryDb.copy(status = newStatus.value)))
+      updated    <- entryDbToDomain(updatedDto)
     } yield updated
-  }
 
   def delete(id: LibraryEntryId): Future[Unit] =
     repository.delete(id).flatMap {
-      case 0 => Future.failed(new IllegalArgumentException(s"There is no Library Entry for uid: $id"))
+      case 0 => EntryNotFound
       case 1 => Future.successful(())
     }
+
+  private val EntryNotFound =
+    Future.failed(new IllegalArgumentException(s"There is no Library Entry with this UUID!"))
+
+  private def resolveAction[T](action: Future[Option[T]]) =
+    action.flatMap {
+      case Some(entry) => Future.successful(entry)
+      case None        => EntryNotFound
+    }
+
+  private def getEntryDb(id: LibraryEntryId): Future[LibraryEntryDbDto] =
+    resolveAction(repository.get(id))
+
+  private def entryDbToDomain(entryDb: LibraryEntryDbDto) =
+    entryDb.toDomain match {
+      case Success(e) => Future.successful(e)
+      case Failure(ex) =>
+        log.error(s"Invalid library entry data in DB for uid: `id`! ${ex.getMessage}")
+        Future.failed(new IllegalStateException(s"Library entry for id has a wrong format in DB! ${ex.getMessage}"))
+    }
+
 }

--- a/src/test/scala/io/scalac/tezos/translator/routes/dto/DTOValidationSpec.scala
+++ b/src/test/scala/io/scalac/tezos/translator/routes/dto/DTOValidationSpec.scala
@@ -3,11 +3,11 @@ package io.scalac.tezos.translator.routes.dto
 import cats.data.NonEmptyList
 import cats.syntax.option._
 import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.refineMV
 import io.scalac.tezos.translator.model.types.ContactData.{ Content, EmailReq, EmailS, Name, NameReq, Phone, PhoneReq }
+import io.scalac.tezos.translator.model.types.Library._
 import io.scalac.tezos.translator.routes.dto.DTOValidation.{ DTOValidationError, FieldIsInvalid }
 import org.scalatest.{ Matchers, WordSpec }
-import eu.timepit.refined.refineMV
-import io.scalac.tezos.translator.model.types.Library._
 
 class DTOValidationSpec extends WordSpec with Matchers {
 
@@ -49,62 +49,62 @@ class DTOValidationSpec extends WordSpec with Matchers {
 
   }
 
-  "DTOValidation.validateLibraryEntryRoutesDto" should {
+  "DTOValidation.validateLibraryEntryRoutesNewDto" should {
 
     "pass validation" when {
 
       "all data is given" in {
-        val input = validLibraryEntryRoutesDto()
+        val input = validLibraryEntryRoutesNewDto()
 
-        DTOValidation.validateLibraryEntryRoutesDto(input) shouldBe Right(input)
+        DTOValidation.validateLibraryEntryRoutesNewDto(input) shouldBe Right(input)
       }
 
       "author is not given" in {
-        val input = validLibraryEntryRoutesDto(author = None)
+        val input = validLibraryEntryRoutesNewDto(author = None)
 
-        DTOValidation.validateLibraryEntryRoutesDto(input) shouldBe Right(input)
+        DTOValidation.validateLibraryEntryRoutesNewDto(input) shouldBe Right(input)
       }
 
       "email is not given" in {
-        val input = validLibraryEntryRoutesDto(email = None)
+        val input = validLibraryEntryRoutesNewDto(email = None)
 
-        DTOValidation.validateLibraryEntryRoutesDto(input) shouldBe Right(input)
+        DTOValidation.validateLibraryEntryRoutesNewDto(input) shouldBe Right(input)
       }
 
       "description is not given" in {
-        val input = validLibraryEntryRoutesDto(description = None)
+        val input = validLibraryEntryRoutesNewDto(description = None)
 
-        DTOValidation.validateLibraryEntryRoutesDto(input) shouldBe Right(input)
+        DTOValidation.validateLibraryEntryRoutesNewDto(input) shouldBe Right(input)
       }
 
       "description is an empty string" in {
-        val input = validLibraryEntryRoutesDto(description = None)
+        val input = validLibraryEntryRoutesNewDto(description = None)
 
-        DTOValidation.validateLibraryEntryRoutesDto(input) shouldBe Right(input.copy(description = None))
+        DTOValidation.validateLibraryEntryRoutesNewDto(input) shouldBe Right(input.copy(description = None))
       }
 
       "author, email is not given" in {
-        val input = validLibraryEntryRoutesDto(author = None, email = None)
+        val input = validLibraryEntryRoutesNewDto(author = None, email = None)
 
-        DTOValidation.validateLibraryEntryRoutesDto(input) shouldBe Right(input)
+        DTOValidation.validateLibraryEntryRoutesNewDto(input) shouldBe Right(input)
       }
 
       "email, description is not given" in {
-        val input = validLibraryEntryRoutesDto(email = None, description = None)
+        val input = validLibraryEntryRoutesNewDto(email = None, description = None)
 
-        DTOValidation.validateLibraryEntryRoutesDto(input) shouldBe Right(input)
+        DTOValidation.validateLibraryEntryRoutesNewDto(input) shouldBe Right(input)
       }
 
       "author, description is not given" in {
-        val input = validLibraryEntryRoutesDto(author = None, description = None)
+        val input = validLibraryEntryRoutesNewDto(author = None, description = None)
 
-        DTOValidation.validateLibraryEntryRoutesDto(input) shouldBe Right(input)
+        DTOValidation.validateLibraryEntryRoutesNewDto(input) shouldBe Right(input)
       }
 
       "author, email, description is not given" in {
-        val input = validLibraryEntryRoutesDto(author = None, email = None, description = None)
+        val input = validLibraryEntryRoutesNewDto(author = None, email = None, description = None)
 
-        DTOValidation.validateLibraryEntryRoutesDto(input) shouldBe Right(input)
+        DTOValidation.validateLibraryEntryRoutesNewDto(input) shouldBe Right(input)
       }
 
     }
@@ -120,13 +120,13 @@ class DTOValidationSpec extends WordSpec with Matchers {
      content: Content      = Content(refineMV[NonEmpty]("content"))
    ): SendEmailRoutesDto = SendEmailRoutesDto(name, phone, email, content)
 
-  private def validLibraryEntryRoutesDto(
+  private def validLibraryEntryRoutesNewDto(
      title: Title                     = Title(refineMV[NotEmptyAndNotLong]("title")),
      author: Option[Author]           = Author(refineMV[NotEmptyAndNotLong]("author")).some,
      email: Option[EmailS]            = Some(EmailS(refineMV[EmailReq]("email@email.com"))),
      description: Option[Description] = Description(refineMV[NotEmptyAndNotLong]("description")).some,
      micheline: Micheline             = Micheline(refineMV[NonEmpty]("micheline")),
      michelson: Michelson             = Michelson(refineMV[NonEmpty]("michelson"))
-   ): LibraryEntryRoutesDto = LibraryEntryRoutesDto(title, author, email, description, micheline, michelson)
+   ): LibraryEntryRoutesNewDto = LibraryEntryRoutesNewDto(title, author, email, description, micheline, michelson)
 
 }


### PR DESCRIPTION

* Entries returned from API now have ID field also for unauthenticated users
* This applies to `GET /v1/library` endpoint
* Added endpoint for getting single entry with `GET /v1/library/{entryId}`
* Changed endpoint for updating to `PUT /v1/library/{entryId}`
* Changed endpoint for removing to `DELETE /v1/library/{entryId}`
* Fixed minor spelling errors, refactored some code
